### PR TITLE
Fix type of password input field

### DIFF
--- a/addon/components/mu-login.hbs
+++ b/addon/components/mu-login.hbs
@@ -11,7 +11,7 @@
     <Input
       @id="mu-login-password"
       @value={{this.password}}
-      type="password" />
+      @type="password" />
   </div>
   <div class="feedback-message">
     {{#if this.isAuthenticating}}


### PR DESCRIPTION
Type of password input field must be `password` instead of `text`