### PR TITLE
Add support for ember-simple-auth v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
     "@babel/core": "^7.22.10",
     "ember-auto-import": "^2.6.3",
     "ember-cli-babel": "^8.0.0",
-    "ember-cli-htmlbars": "^6.3.0",
-    "ember-simple-auth": "^6.0.0"
+    "ember-cli-htmlbars": "^6.3.0"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.22.10",
@@ -61,6 +60,7 @@
     "ember-page-title": "^8.0.0",
     "ember-qunit": "^7.0.0",
     "ember-resolver": "^11.0.1",
+    "ember-simple-auth": "^7.0.0",
     "ember-source": "~5.2.0",
     "ember-source-channel-url": "^3.0.0",
     "ember-template-lint": "^5.11.2",


### PR DESCRIPTION
This removes the dependency on ember-simple-auth  since it is already a peerDep with a wide range:

https://github.com/mu-semtech/ember-mu-login/blob/761dec15dc5c66d3c3119dd9325343be5058c467/package.json#L84

This would allow apps to use v7 as well. v7 is API compatible with v5 and v6, so no code changes are needed here.